### PR TITLE
Added option to prevent the `development` group gems installation in the Semaphore config

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -11,7 +11,7 @@ global_job_config:
       - checkout
       - sem-version ruby 3.0.4
       - bundle config path 'vendor/bundle'
-      - bundle install
+      - bundle install --without development
   env_vars:
     - name: TZ
       value: "/usr/share/zoneinfo/America/New_York"

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -11,7 +11,8 @@ global_job_config:
       - checkout
       - sem-version ruby 3.0.4
       - bundle config path 'vendor/bundle'
-      - bundle install --without development
+      - bundle config set --local without 'development'
+      - bundle install
   env_vars:
     - name: TZ
       value: "/usr/share/zoneinfo/America/New_York"


### PR DESCRIPTION
Based on: https://github.com/bigbinary/neeto-engineering-web/issues/321
Also, refer to the discussion for more context: https://github.com/bigbinary/neeto-monitor-ruby/pull/22#issuecomment-1430985350

@vivek-viswam-rv _a
